### PR TITLE
Fixed: Archiving not working, when Bitcode and App Thinning is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src
 include/openssl
 *.gz
 *.framework
+lib

--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -91,8 +91,9 @@ if [ $FWTYPE == "dynamic" ]; then
             -compatibility_version $COMPAT_VERSION \
             -current_version $CURRENT_VERSION \
             -application_extension \
+            -dylib_install_name $INSTALL_NAME \
             -o $FWNAME.dylib
-        install_name_tool -id $INSTALL_NAME $FWNAME.dylib
+            #install_name_tool -id $INSTALL_NAME $FWNAME.dylib
 
         cd ..
     done

--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -91,7 +91,7 @@ if [ $FWTYPE == "dynamic" ]; then
             -compatibility_version $COMPAT_VERSION \
             -current_version $CURRENT_VERSION \
             -application_extension \
-            -dylib_install_name $INSTALL_NAME \
+            -install_name $INSTALL_NAME \
             -o $FWNAME.dylib
             #install_name_tool -id $INSTALL_NAME $FWNAME.dylib
 


### PR DESCRIPTION
This change fixes archiving not working in Xcode, when Bitcode and App thinning is enabled. Without this change Xcode still assumes openssl.dylib as installname, when doing the recompile from bitcode.