### PR TITLE
update to support 1.1.1b

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -25,7 +25,7 @@ set -u
 # SCRIPT DEFAULTS
 
 # Default version in case no version is specified
-DEFAULTVERSION="1.1.0i"
+DEFAULTVERSION="1.1.1b"
 
 # Default (=full) set of architectures (OpenSSL <= 1.0.2) or targets (OpenSSL >= 1.1.0) to build
 #DEFAULTARCHS="ios_x86_64 ios_arm64 ios_armv7s ios_armv7 tv_x86_64 tv_arm64 mac_x86_64"

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -1,5 +1,5 @@
 ## -*- mode: perl; -*-
-
+my %targets = ();
 %targets = (
     ## Base settings for cross-compile
     # Based on 10-main.conf: iphoneos-cross


### PR DESCRIPTION
Previous script has problem to compile 1.1.1b. Make small change to support 1.1.1b and use 1.1.1b as default version.