### PR TITLE
Upgrade to OpenSSL 1.1.1

### DIFF
--- a/OpenSSL-Apple.podspec.template
+++ b/OpenSSL-Apple.podspec.template
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
     openssl_version   = "%OPENSSL-VERSION%"
-    script_version    = "4"
+    openssl_targets   = "ios-sim-cross-x86_64 ios64-cross-arm64 macos64-x86_64"
+    script_version    = "5a"
 
     s.name            = "OpenSSL-Apple"
     s.version         = "#{openssl_version}.#{script_version}"
@@ -12,17 +13,13 @@ Pod::Spec.new do |s|
     s.license         = { :type => 'Apache', :file => 'LICENSE' }
 
     s.prepare_command = <<-CMD
-./build-libssl.sh --version=#{openssl_version}
+./build-libssl.sh --version="#{openssl_version}" --targets="#{openssl_targets}"
 ./create-openssl-framework.sh dynamic
     CMD
 
     s.ios.deployment_target         = "11.0"
     s.ios.vendored_frameworks       = "frameworks/iPhone/openssl.framework"
-    s.tvos.deployment_target        = "11.0"
-    s.tvos.vendored_frameworks      = "frameworks/AppleTV/openssl.framework"
     s.osx.deployment_target         = "10.11"
     s.osx.vendored_frameworks       = "frameworks/MacOSX/openssl.framework"
-    s.watchos.deployment_target     = "4.0"
-    s.watchos.vendored_frameworks   = "frameworks/WatchOS/openssl.framework"
     s.requires_arc                  = false
 end

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![iOS support](https://img.shields.io/badge/iOS-11+-blue.svg)
 ![tvOS support](https://img.shields.io/badge/tvOS-11+-blue.svg)
 ![macOS support](https://img.shields.io/badge/macOS-10.11+-blue.svg)
+![watchOS support](https://img.shields.io/badge/watchOS-4.0+-blue.svg)
 ![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.0i-green.svg)
 ![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.0.2o-green.svg)
 [![license](https://img.shields.io/badge/license-Apache%202.0-lightgrey.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![tvOS support](https://img.shields.io/badge/tvOS-11+-blue.svg)
 ![macOS support](https://img.shields.io/badge/macOS-10.11+-blue.svg)
 ![watchOS support](https://img.shields.io/badge/watchOS-4.0+-blue.svg)
-![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.0i-green.svg)
+![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.1d-green.svg)
 ![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.0.2o-green.svg)
 [![license](https://img.shields.io/badge/license-Apache%202.0-lightgrey.svg)](LICENSE)
 
@@ -20,10 +20,10 @@ Compile OpenSSL 1.0.2k for all archs:
 ./build-libssl.sh --version=1.0.2k
 ```
 
-Compile OpenSSL 1.1.0f for all targets:
+Compile OpenSSL 1.1.1d for all targets:
 
 ```
-./build-libssl.sh --version=1.1.0f
+./build-libssl.sh --version=1.1.1d
 ```
 
 Compile OpenSSL 1.0.2k for specific archs:
@@ -32,10 +32,10 @@ Compile OpenSSL 1.0.2k for specific archs:
 ./build-libssl.sh --version=1.0.2k --archs="ios_armv7 ios_arm64 mac_i386"
 ```
 
-Compile OpenSSL 1.1.0f for specific targets:
+Compile OpenSSL 1.1.1d for specific targets:
 
 ```
-./build-libssl.sh --version=1.1.0f --targets="ios-cross-armv7 macos64-x86_64"
+./build-libssl.sh --version=1.1.1d --targets="ios-cross-armv7 macos64-x86_64"
 ```
 
 For all options see:

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -138,9 +138,9 @@ run_configure()
   echo "  Configure..."
   set +e
   if [ "${LOG_VERBOSE}" == "verbose" ]; then
-    ./Configure ${LOCAL_CONFIG_OPTIONS} | tee "${LOG}"
+    ./Configure ${LOCAL_CONFIG_OPTIONS} no-tests | tee "${LOG}"
   else
-    (./Configure ${LOCAL_CONFIG_OPTIONS} > "${LOG}" 2>&1) & spinner
+    (./Configure ${LOCAL_CONFIG_OPTIONS} no-tests > "${LOG}" 2>&1) & spinner
   fi
 
   # Check for error status

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -25,9 +25,9 @@ set -u
 # SCRIPT DEFAULTS
 
 # Default version in case no version is specified
-DEFAULTVERSION="1.1.0i"
+DEFAULTVERSION="1.1.1d"
 
-# Default (=full) set of architectures (OpenSSL <= 1.0.2) or targets (OpenSSL >= 1.1.0) to build
+# Default (=full) set of architectures (OpenSSL <= 1.0.2) or targets (OpenSSL >= 1.1.1) to build
 #DEFAULTARCHS="ios_x86_64 ios_arm64 ios_armv7s ios_armv7 tv_x86_64 tv_arm64 mac_x86_64"
 #DEFAULTTARGETS="ios-sim-cross-x86_64 ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7 tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64"
 DEFAULTARCHS="ios_x86_64 ios_arm64 tv_x86_64 tv_arm64 mac_x86_64 watchos_armv7k watchos_arm64_32 watchos_i386"
@@ -64,7 +64,7 @@ echo_help()
   echo "     --archs=\"ARCH ARCH ...\"       Space-separated list of architectures to build"
   echo "                                     Options: ${DEFAULTARCHS}"
   echo
-  echo "Options for OpenSSL 1.1.0 and higher ONLY"
+  echo "Options for OpenSSL 1.1.1 and higher ONLY"
   echo "     --deprecated                  Exclude no-deprecated configure option and build with deprecated methods"
   echo "     --targets=\"TARGET TARGET ...\" Space-separated list of build targets"
   echo "                                     Options: ${DEFAULTTARGETS}"
@@ -295,7 +295,7 @@ elif [[ -n "${VERSION}" && ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+[a-z]*$ ]]; 
 elif [ -n "${BRANCH}" ]; then
   # Verify version number format. Expected: dot notation
   if [[ ! "${BRANCH}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Unknown branch version number format. Examples: 1.0.2, 1.1.0"
+    echo "Unknown branch version number format. Examples: 1.0.2, 1.1.1"
     exit 1
 
   # Valid version number, determine latest version
@@ -320,7 +320,7 @@ fi
 # Build type:
 # In short, type "archs" is used for OpenSSL versions in the 1.0 branch and type "targets" for later versions.
 #
-# Significant changes to the build process were introduced with OpenSSL 1.1.0. As a result, this script was updated
+# Significant changes to the build process were introduced with OpenSSL 1.1.1. As a result, this script was updated
 # to include two separate build loops for versions <= 1.0 and versions >= 1.1. The type "archs" matches the key variable
 # used to determine for which platforms to build for the 1.0 branch. Since 1.1, all platforms are defined in a separate/
 # custom configuration file as build targets. Therefore the key variable and type are called targets for 1.1 (and later).
@@ -457,7 +457,7 @@ else
   echo "Using ${OPENSSL_ARCHIVE_FILE_NAME}"
 fi
 
-# Set reference to custom configuration (OpenSSL 1.1.0)
+# Set reference to custom configuration (OpenSSL 1.1.1)
 # See: https://github.com/openssl/openssl/commit/afce395cba521e395e6eecdaf9589105f61e4411
 export OPENSSL_LOCAL_CONFIG_DIR="${SCRIPTDIR}/config"
 

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -1,5 +1,7 @@
 ## -*- mode: perl; -*-
 
+my %targets = ();
+
 %targets = (
     ## Base settings for cross-compile
     # Based on 10-main.conf: iphoneos-cross


### PR DESCRIPTION
OpenSSL 1.1.0 was deprecated in favor of 1.1.1. However, 1.0.2 is still supported and should be unaffected by this PR.

PR breaks support for 1.1.0 due to a minimal change in configuration file, as seen here: https://github.com/x2on/OpenSSL-for-iPhone/pull/170