### PR TITLE
Accurate version bookkeeping

### DIFF
--- a/assets/AppleTV/Info.plist
+++ b/assets/AppleTV/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>
-	<string>11.0</string>
+	<string>$(MIN_SDK_VERSION)</string>
 </dict>
 </plist>

--- a/assets/AppleTV/Info.plist
+++ b/assets/AppleTV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(OPENSSL_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>

--- a/assets/MacOSX/Info.plist
+++ b/assets/MacOSX/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(OPENSSL_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>

--- a/assets/MacOSX/Info.plist
+++ b/assets/MacOSX/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>
-	<string>10.11</string>
+	<string>$(MIN_SDK_VERSION)</string>
 </dict>
 </plist>

--- a/assets/WatchOS/Info.plist
+++ b/assets/WatchOS/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>
-	<string>4.0</string>
+	<string>$(MIN_SDK_VERSION)</string>
 </dict>
 </plist>

--- a/assets/WatchOS/Info.plist
+++ b/assets/WatchOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(OPENSSL_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>

--- a/assets/iPhone/Info.plist
+++ b/assets/iPhone/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>
-	<string>11.0</string>
+	<string>$(MIN_SDK_VERSION)</string>
 </dict>
 </plist>

--- a/assets/iPhone/Info.plist
+++ b/assets/iPhone/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(OPENSSL_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MinimumOSVersion</key>

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -53,8 +53,13 @@ echo_help()
   echo " -h, --help                        Print help (this message)"
   echo "     --macos-sdk=SDKVERSION        Override macOS SDK version"
   echo "     --ios-sdk=SDKVERSION          Override iOS SDK version"
-  echo "     --noparallel                  Disable running make with parallel jobs (make -j)"
   echo "     --tvos-sdk=SDKVERSION         Override tvOS SDK version"
+  echo "     --watchos-sdk=SDKVERSION      Override watchOS SDK version"
+  echo "     --min-macos-sdk=SDKVERSION    Set minimum macOS SDK version (default: $MACOS_MIN_SDK_VERSION)"
+  echo "     --min-ios-sdk=SDKVERSION      Set minimum iOS SDK version (default: $IOS_MIN_SDK_VERSION)"
+  echo "     --min-tvos-sdk=SDKVERSION     Set minimum tvOS SDK version (default: $TVOS_MIN_SDK_VERSION)"
+  echo "     --min-watchos-sdk=SDKVERSION  Set minimum watchOS SDK version (default: $WATCHOS_MIN_SDK_VERSION)"
+  echo "     --noparallel                  Disable running make with parallel jobs (make -j)"
   echo "     --disable-bitcode             Disable embedding Bitcode"
   echo " -v, --verbose                     Enable verbose logging"
   echo "     --verbose-on-error            Dump last 500 lines from log file if an error occurs (for Travis builds)"
@@ -265,6 +270,22 @@ case $i in
     WATCHOS_SDKVERSION="${i#*=}"
     shift
     ;;
+  --min-macos-sdk=*)
+    MACOS_MIN_SDK_VERSION="${i#*=}"
+    shift
+    ;;
+  --min-ios-sdk=*)
+    IOS_MIN_SDK_VERSION="${i#*=}"
+    shift
+    ;;
+  --min-tvos-sdk=*)
+    TVOS_MIN_SDK_VERSION="${i#*=}"
+    shift
+    ;;
+  --min-watchos-sdk=*)
+    WATCHOS_MIN_SDK_VERSION="${i#*=}"
+    shift
+    ;;
   -v|--verbose)
     LOG_VERBOSE="verbose"
     ;;
@@ -413,10 +434,10 @@ if [ "${BUILD_TYPE}" == "archs" ]; then
 else
   echo "  Targets: ${TARGETS}"
 fi
-echo "  macOS SDK: ${MACOS_SDKVERSION}"
-echo "  iOS SDK: ${IOS_SDKVERSION}"
-echo "  tvOS SDK: ${TVOS_SDKVERSION}"
-echo "  watchOS SDK: ${WATCHOS_SDKVERSION}"
+echo "  macOS SDK: ${MACOS_SDKVERSION} (min ${MACOS_MIN_SDK_VERSION})"
+echo "  iOS SDK: ${IOS_SDKVERSION} (min ${IOS_MIN_SDK_VERSION})"
+echo "  tvOS SDK: ${TVOS_SDKVERSION} (min ${TVOS_MIN_SDK_VERSION})"
+echo "  watchOS SDK: ${WATCHOS_SDKVERSION} (min ${WATCHOS_MIN_SDK_VERSION})"
 if [ "${CONFIG_DISABLE_BITCODE}" == "true" ]; then
   echo "  Bitcode embedding disabled"
 fi

--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -157,6 +157,9 @@ if [ $FWTYPE == "dynamic" ]; then
             lipo -create ${DYLIBS[@]} -output $FWDIR/$FWNAME
             cp -r include/$FWNAME/* $FWDIR/Headers/
             cp -L assets/$SYS/Info.plist $FWDIR/Info.plist
+            MIN_SDK_VERSION=$(get_min_sdk "$FWDIR/$FWNAME")
+            sed -e "s/\\\$(MIN_SDK_VERSION)/$MIN_SDK_VERSION/g" \
+                -i '' "$FWDIR/Info.plist"
             echo "Created $FWDIR"
             check_bitcode $FWDIR
         else
@@ -176,6 +179,9 @@ else
             libtool -static -o $FWDIR/$FWNAME lib/libcrypto-$SYS.a lib/libssl-$SYS.a
             cp -r include/$FWNAME/* $FWDIR/Headers/
             cp -L assets/$SYS/Info.plist $FWDIR/Info.plist
+            MIN_SDK_VERSION=$(get_min_sdk "$FWDIR/$FWNAME")
+            sed -e "s/\\\$(MIN_SDK_VERSION)/$MIN_SDK_VERSION/g" \
+                -i '' "$FWDIR/Info.plist"
             echo "Created $FWDIR"
             check_bitcode $FWDIR
         else


### PR DESCRIPTION
This patch set improves the accuracy of version information in produced frameworks.

Now it’s possible to set the minimum SDK version to support with the new command-line flags:

- `--min-macos-sdk`
- `--min-ios-sdk`
- `--min-tvos-sdk`
- `--min-watchos-sdk`

Additionally, minimum SDK information is accurately translated into the resulting binary files and framework bundles. Now it should be all consistent between binaries, Info.plist, etc.

Finally, the OpenSSL version is now written into ‘marketing version’ field of Info.plist files so that vulnerability analysis tools have an easier time figuring out the version of the OpenSSL framework.