### PR TITLE
Don’t symlink macOS framework if not building it

### DIFF
--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -149,6 +149,9 @@ for SYS in ${ALL_SYSTEMS[@]}; do
     if [[ $SYS == "MacOSX" ]]; then
         SYSDIR="$FWROOT/$SYS"
         FWDIR="$SYSDIR/$FWNAME.framework"
+        if [[ ! -e "$FWDIR" ]]; then
+            continue
+        fi
         cd $FWDIR
 
         mkdir "Versions"


### PR DESCRIPTION
If we are not building macOS targets then the framework has not been created and we not should go ahead with creating symlinks in it. Check whether the framework directory is there, if it’s not then don’t attempt to create symlinks.

This allows to build OpenSSL, say, only for iOS:

```
./build-libssl.sh --targets="ios-cross-armv7"
./create-openssl-framework.sh dynamic
```

without failing on skipped macOS framework.