### PR TITLE
Adds support for WatchOS Simulator on Xcode 12 (x86_64)

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -30,8 +30,8 @@ DEFAULTVERSION="1.1.1g"
 # Default (=full) set of architectures (OpenSSL <= 1.0.2) or targets (OpenSSL >= 1.1.1) to build
 #DEFAULTARCHS="ios_x86_64 ios_arm64 ios_armv7s ios_armv7 tv_x86_64 tv_arm64 mac_x86_64"
 #DEFAULTTARGETS="ios-sim-cross-x86_64 ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7 tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64"
-DEFAULTARCHS="ios_x86_64 ios_arm64 tv_x86_64 tv_arm64 mac_x86_64 watchos_armv7k watchos_arm64_32 watchos_i386"
-DEFAULTTARGETS="ios-sim-cross-x86_64 ios64-cross-arm64 ios64-cross-arm64e tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64 watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-i386"
+DEFAULTARCHS="ios_x86_64 ios_arm64 tv_x86_64 tv_arm64 mac_x86_64 watchos_armv7k watchos_arm64_32 watchos_i386 watchos_x86_64"
+DEFAULTTARGETS="ios-sim-cross-x86_64 ios64-cross-arm64 ios64-cross-arm64e tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64 watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-i386 watchos-sim-cross-x86_64"
 
 # Minimum iOS/tvOS SDK version to build for
 IOS_MIN_SDK_VERSION="12.0"
@@ -617,6 +617,9 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
       ;;
       *_watchos_i386.h)
         DEFINE_CONDITION="TARGET_OS_SIMULATOR && TARGET_CPU_X86 || TARGET_OS_EMBEDDED"
+      ;;
+      *_watchos_x86_64.h)
+        DEFINE_CONDITION="TARGET_OS_SIMULATOR && TARGET_CPU_X86_64 || TARGET_OS_EMBEDDED"
       ;;
       *)
         # Don't run into unexpected cases by setting the default condition to false

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -60,10 +60,26 @@ my %targets = ();
         defines          => [ "HAVE_FORK=0" ],
         sys_id           => "WatchOS",
     },
+    "watchos-cross-arm64" => {
+        inherit_from     => [ "darwin-common", "watchos-cross-base", asm("aarch64_asm") ],
+        cflags           => add("-arch arm64 -fembed-bitcode"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        perlasm_scheme   => "ios64",
+        defines          => [ "HAVE_FORK=0" ],
+        sys_id           => "WatchOS",
+    },
+    
 
     "watchos-sim-cross-i386" => {
         inherit_from     => [ "darwin-common", "watchos-cross-base"],
         cflags           => add("-arch i386 -fembed-bitcode"),
+        defines          => [ "HAVE_FORK=0" ],
+        sys_id           => "WatchOS",
+    },
+
+    "watchos-sim-cross-x86_64" => {
+        inherit_from     => [ "darwin64-x86_64-cc", "watchos-cross-base"],
+        cflags           => add("-fembed-bitcode"),
         defines          => [ "HAVE_FORK=0" ],
         sys_id           => "WatchOS",
     },

--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -120,7 +120,7 @@ if [ $FWTYPE == "dynamic" ]; then
     COMPAT_VERSION="1.0.0"
     CURRENT_VERSION="1.0.0"
 
-    RX='([A-z]+)([0-9]+(\.[0-9]+)*)-([A-z0-9]+)\.sdk'
+    RX='([A-z]+)([0-9]+(\.[0-9]+)*)-([A-z0-9_]+)\.sdk'
 
     cd bin
     for TARGETDIR in `ls -d *.sdk`; do
@@ -184,7 +184,12 @@ if [ $FWTYPE == "dynamic" ]; then
     for SYS in ${ALL_SYSTEMS[@]}; do
         SYSDIR="$FWROOT/$SYS"
         FWDIR="$SYSDIR/$FWNAME.framework"
-        DYLIBS=(bin/${SYS}*/$FWNAME.dylib)
+
+        if [[ $SYS == "WatchOS" ]]; then
+			DYLIBS=(bin/Watch*/$FWNAME.dylib)
+		else
+			DYLIBS=(bin/${SYS}*/$FWNAME.dylib)
+		fi
 
         if [[ ${#DYLIBS[@]} -gt 0 && -e ${DYLIBS[0]} ]]; then
             echo "Creating framework for $SYS"

--- a/scripts/build-loop-archs.sh
+++ b/scripts/build-loop-archs.sh
@@ -55,7 +55,6 @@ do
   # Set env vars for Configure
   export CROSS_TOP="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
   export CROSS_SDK="${PLATFORM}${SDKVERSION}.sdk"
-  echo CROSS_SDK
   export BUILD_TOOLS="${DEVELOPER}"
   export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}"
 

--- a/scripts/build-loop-archs.sh
+++ b/scripts/build-loop-archs.sh
@@ -41,9 +41,9 @@ do
     PLATFORM="AppleTVOS"
   elif [[ "${ARCH}" == "mac_x86_64" || "${ARCH}" == "mac_i386" ]]; then
     PLATFORM="MacOSX"
-  elif [[ "${ARCH}" == "watchos_arm64_32" || "${ARCH}" == "watchos_armv7k" ]]; then
+  elif [[ "${ARCH}" == "watchos_arm64_32" || "${ARCH}" == "watchos_armv7k" || "${ARCH}" == "watchos_arm64" ]]; then
     PLATFORM="WatchOS"
-  elif [[ "${ARCH}" == "watchos_i386" ]]; then
+  elif [[ "${ARCH}" == "watchos_i386" || "${ARCH}" == "watchos_x86_64" ]]; then
     PLATFORM="WatchSimulator"
   else
     PLATFORM="iPhoneOS"
@@ -55,6 +55,7 @@ do
   # Set env vars for Configure
   export CROSS_TOP="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
   export CROSS_SDK="${PLATFORM}${SDKVERSION}.sdk"
+  echo CROSS_SDK
   export BUILD_TOOLS="${DEVELOPER}"
   export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}"
 


### PR DESCRIPTION
First of all, thanks for this fork! With Xcode 12, we had issues building for the WatchOS simulator since it now seems to use x86_64 for some models. This PR adds support for that