### PR TITLE
Fix support for WatchOS Simulator on Xcode 12.4 (ARM64)

### DIFF
--- a/OpenSSL-Apple.podspec
+++ b/OpenSSL-Apple.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-    openssl_version   = "1.1.1h"
+    openssl_version   = "1.1.1j"
     openssl_targets   = "ios-sim-cross-x86_64 ios-sim-cross-arm64 ios64-cross-arm64 ios64-cross-arm64e macos64-x86_64 macos64-arm64 mac-catalyst-x86_64 mac-catalyst-arm64"
     script_version    = "10"
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![macOS Catalyst support](https://img.shields.io/badge/macOS%20Catalyst-10.15+-blue.svg)
 ![watchOS support](https://img.shields.io/badge/watchOS-4.0+-blue.svg)
 ![tvOS support](https://img.shields.io/badge/tvOS-12+-blue.svg)
-![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.1h-green.svg)
+![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.1j-green.svg)
 [![license](https://img.shields.io/badge/license-Apache%202.0-lightgrey.svg)](LICENSE)
 
 This is a fork of the popular work by [Felix Schulze](https://github.com/x2on), that is a set of scripts for using self-compiled builds of the OpenSSL library on the iPhone and the Apple TV.
@@ -14,16 +14,16 @@ However, this repository focuses more on framework-based setups and also adds ma
 
 # Compile library
 
-Compile OpenSSL 1.1.1h for all targets:
+Compile OpenSSL 1.1.1j for all targets:
 
 ```
-./build-libssl.sh --version=1.1.1h
+./build-libssl.sh --version=1.1.1j
 ```
 
-Compile OpenSSL 1.1.1h for specific targets:
+Compile OpenSSL 1.1.1j for specific targets:
 
 ```
-./build-libssl.sh --version=1.1.1h --targets="ios64-cross-arm64 macos64-x86_64 macos64-arm64"
+./build-libssl.sh --version=1.1.1j --targets="ios64-cross-arm64 macos64-x86_64 macos64-arm64"
 ```
 
 For all options see:

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -32,7 +32,7 @@ DEFAULTTARGETS=`cat <<TARGETS
 ios-sim-cross-x86_64 ios-sim-cross-arm64 ios64-cross-arm64 ios64-cross-arm64e
 macos64-x86_64 macos64-arm64
 mac-catalyst-x86_64 mac-catalyst-arm64
-watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-x86_64 watchos-sim-cross-i386
+watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-x86_64 watchos-sim-cross-i386 watchos-sim-cross-arm64
 tvos-sim-cross-x86_64 tvos64-cross-arm64
 TARGETS`
 
@@ -571,16 +571,19 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
         DEFINE_CONDITION="(TARGET_OS_MACCATALYST || (TARGET_OS_IOS && TARGET_OS_SIMULATOR)) && TARGET_CPU_ARM64"
       ;;
       *_watchos_armv7k.h)
-        DEFINE_CONDITION="TARGET_OS_WATCHOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARMV7K"
+        DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_EMBEDDED && TARGET_CPU_ARM"
       ;;
       *_watchos_arm64_32.h)
-        DEFINE_CONDITION="TARGET_OS_WATCHOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64_32"
+        DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"
       ;;
       *_watchos_sim_x86_64.h)
-        DEFINE_CONDITION="TARGET_OS_SIMULATOR && TARGET_CPU_X86_64 || TARGET_OS_EMBEDDED"
+        DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_SIMULATOR && TARGET_CPU_X86_64"
+      ;;
+      *_watchos_sim_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_SIMULATOR && TARGET_CPU_ARM64"
       ;;
       *_watchos_sim_i386.h)
-        DEFINE_CONDITION="TARGET_OS_SIMULATOR && TARGET_CPU_X86 || TARGET_OS_EMBEDDED"
+        DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_SIMULATOR && TARGET_CPU_X86"
       ;;
       *_tvos_arm64.h)
         DEFINE_CONDITION="TARGET_OS_TV && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -25,7 +25,7 @@ set -u
 # SCRIPT DEFAULTS
 
 # Default version in case no version is specified
-DEFAULTVERSION="1.1.1h"
+DEFAULTVERSION="1.1.1j"
 
 # Default (=full) set of targets (OpenSSL >= 1.1.1) to build
 DEFAULTTARGETS=`cat <<TARGETS

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -71,18 +71,6 @@ my %targets = ();
         sys_id           => "iOS",
     },
 
-    ## Apple macOS
-
-    # Base (arm64)
-    "darwin64-arm64-cc" => {
-        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
-        CFLAGS           => add("-Wall"),
-        cflags           => add("-arch arm64"),
-        lib_cppflags     => add("-DL_ENDIAN"),
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
-        perlasm_scheme   => "ios64",
-    },
-
     # Device
     "macos64-x86_64" => {
         inherit_from     => [ "darwin64-x86_64-cc", "macos-base" ],
@@ -131,6 +119,12 @@ my %targets = ();
     "watchos-sim-cross-x86_64" => {
         inherit_from     => [ "darwin64-x86_64-cc", "watchos-cross-base"],
         cflags           => add("-fembed-bitcode"),
+        defines          => [ "HAVE_FORK=0" ],
+        sys_id           => "WatchOS",
+    },
+    "watchos-sim-cross-arm64" => {
+        inherit_from     => [ "darwin64-arm64-cc", "watchos-cross-base"],
+        cflags           => add("-target arm64-apple-watchos7.2-simulator -mwatchos-version-min=7.2 -fembed-bitcode"),
         defines          => [ "HAVE_FORK=0" ],
         sys_id           => "WatchOS",
     },


### PR DESCRIPTION
Since Xcode 12 and throughout Xcode 12.4, Apple seems to be hardening the validation of Xcframeworks that are used in iOS/watchOS projects. This PR attempts to make the generated Xcframework complete enough that Xcode won't complain when used on watchOS projects:

- Updates OpenSSL to 1.1.1j to add support for ARM64 watchOS simulator (which 1.1.1h didn't).
- Adds the `watchos-sim-cross-arm64` target.
- Fixes the define conditions for watchOS in the generated `opensslconf.h` file to stop using the deprecated `TARGET_OS_EMBEDDED` and the apparently non-existing `TARGET_CPU_ARMV7K` and `TARGET_CPU_ARM64_32` defines.